### PR TITLE
Fix GitHub Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: 'microsoft'
+          distribution: 'temurin'
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: 'microsoft'
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@
 # against bad commits.
 
 name: build
-on: [pull_request, push]
+on: [workflow_dispatch, pull_request, push]
 
 jobs:
   build:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx2G -XX:+UseG1GC
 org.gradle.parallel=true
-org.gradle.java.home=C:\\Program Files\\Java\\jdk-21
 
 # IntelliJ IDEA is not yet fully compatible with configuration cache, see: https://github.com/FabricMC/fabric-loom/issues/1349
 org.gradle.configuration-cache=false


### PR DESCRIPTION
Simply fixes GitHub building by removing a hardcoded value from `gradle.properties` (Ubuntu cannot use values like `C:\\Program Files\\Java\\jdk-21`, even if it did, it does not appear to be the default location for Microsoft's Java distribution).

Build still works locally:
<img width="512" height="73" alt="image" src="https://github.com/user-attachments/assets/ca7c0c81-200a-4204-b388-2a1b078bc093" />

And now on GitHub:
<img width="422" height="502" alt="image" src="https://github.com/user-attachments/assets/62e342ae-7f3d-4613-ac0d-b232360ad691" />
(See run: https://github.com/katniny/idiots-saccharine-totems/actions/runs/19356916720/job/55379873396)

If building *does* start breaking locally after this PR, you're missing PATH values for JAVA_HOME and/or Java in general.
